### PR TITLE
fix(argocd): enable network policies

### DIFF
--- a/Services/Platform/ArgoCD/argocd.application.yaml
+++ b/Services/Platform/ArgoCD/argocd.application.yaml
@@ -16,6 +16,9 @@ spec:
       valuesObject:
         global:
           domain: argocd.saaby.no
+          networkPolicy:
+            create: true
+            defaultDenyIngress: true
         configs:
           params:
             server.insecure: true


### PR DESCRIPTION
## Summary
- Enable Argo CD Helm chart NetworkPolicy creation globally
- Add default deny ingress for the argocd namespace
- Restrict repo-server and Redis ingress to Argo CD components via chart-rendered policies

## Verification
- helm template argo-cd chart 9.5.17 with the new values
- kubectl apply --dry-run=client against rendered chart output
- kubectl kustomize Services/Platform