### PR TITLE
fix: register Wazuh agents with default group

### DIFF
--- a/Services/Security/Wazuh/wazuh-agent.daemonset.yaml
+++ b/Services/Security/Wazuh/wazuh-agent.daemonset.yaml
@@ -39,8 +39,6 @@ spec:
                 secretKeyRef:
                   name: wazuh-authd-pass
                   key: authd.pass
-            - name: WAZUH_AGENT_GROUP
-              value: kubernetes
           volumeMounts:
             - name: host-var-log
               mountPath: /host/var/log


### PR DESCRIPTION
## Summary
- Remove the non-existent WAZUH_AGENT_GROUP=kubernetes setting from the Wazuh agent DaemonSet
- Agents can register against the manager's existing default group instead of failing with 'Invalid group: kubernetes'

## Validation
- kubectl apply --dry-run=client -k Services/Security/Wazuh
- kubectl -n wazuh rollout restart ds/wazuh-agent
- Wazuh control plane recovered after Longhorn/iSCSI node recovery