### PR TITLE
fix: harden Longhorn storage baseline for Wazuh

### DIFF
--- a/Services/Security/Wazuh/indexer_stack/wazuh-indexer/cluster/indexer-sts.yaml
+++ b/Services/Security/Wazuh/indexer_stack/wazuh-indexer/cluster/indexer-sts.yaml
@@ -132,4 +132,4 @@ spec:
         storageClassName: longhorn
         resources:
           requests:
-            storage: 500Mi
+            storage: 10Gi

--- a/Services/Security/Wazuh/wazuh_managers/wazuh-master-sts.yaml
+++ b/Services/Security/Wazuh/wazuh_managers/wazuh-master-sts.yaml
@@ -156,4 +156,4 @@ spec:
         storageClassName: longhorn
         resources:
           requests:
-            storage: 500Mi
+            storage: 2Gi

--- a/Services/Security/Wazuh/wazuh_managers/wazuh-worker-sts.yaml
+++ b/Services/Security/Wazuh/wazuh_managers/wazuh-worker-sts.yaml
@@ -143,4 +143,4 @@ spec:
         storageClassName: longhorn
         resources:
           requests:
-            storage: 500Mi
+            storage: 2Gi

--- a/Setup/Configuration/roles/os_baseline/tasks/main.yml
+++ b/Setup/Configuration/roles/os_baseline/tasks/main.yml
@@ -58,3 +58,23 @@
     name: iscsid
     enabled: true
     state: started
+
+- name: Ensure multipath does not claim Longhorn block devices
+  copy:
+    dest: /etc/multipath/conf.d/longhorn.conf
+    mode: "0644"
+    content: |
+      blacklist {
+          devnode "^sd[a-z0-9]+"
+      }
+
+- name: Disable multipath daemon for Longhorn nodes
+  systemd:
+    name: "{{ item }}"
+    enabled: false
+    masked: true
+    state: stopped
+  failed_when: false
+  loop:
+    - multipathd
+    - multipathd.socket


### PR DESCRIPTION
## Summary
- blacklist Longhorn-hosted block devices from multipath on Kubernetes nodes
- disable/mask multipathd in the Ansible OS baseline to prevent Longhorn iSCSI attach churn
- increase Wazuh manager/indexer volume claim templates from undersized defaults

## Verification
- kubectl apply --dry-run=client -k Services/Security/Wazuh
- live multipath check: multipathd inactive/disabled and Longhorn blacklist present on all k3s nodes
- recreated Wazuh StatefulSets with orphaned PVCs so immutable volumeClaimTemplates match Git
- Wazuh manager/indexer/dashboard/agents all Running