### PR TITLE
fix: reserve less Longhorn disk capacity

### DIFF
--- a/Services/Platform/Longhorn/longhorn.application.yaml
+++ b/Services/Platform/Longhorn/longhorn.application.yaml
@@ -20,6 +20,7 @@ spec:
         defaultSettings:
           defaultDataPath: /var/lib/longhorn
           replicaAutoBalance: best-effort
+          storageReservedPercentageForDefaultDisk: 10
         ingress:
           enabled: true
           ingressClassName: traefik


### PR DESCRIPTION
## Summary
- Lower Longhorn default disk reservation from 30% to 10%
- Keeps enough schedulable capacity for replica rebuilds on the current k3s disks

## Verification
- Patched live Longhorn setting and node disk reservations to 10Gi
- Observed Longhorn nodes report the updated reservation
- Watched degraded Prometheus volume for rebuild