### PR TITLE
fix: allow Longhorn replica rebuild headroom

### DIFF
--- a/Services/Platform/Longhorn/longhorn.application.yaml
+++ b/Services/Platform/Longhorn/longhorn.application.yaml
@@ -21,6 +21,7 @@ spec:
           defaultDataPath: /var/lib/longhorn
           replicaAutoBalance: best-effort
           storageReservedPercentageForDefaultDisk: 10
+          storageOverProvisioningPercentage: 150
         ingress:
           enabled: true
           ingressClassName: traefik


### PR DESCRIPTION
## Summary
- Increase Longhorn storage over-provisioning to 150%
- Gives the current 75Gi node disks enough scheduling headroom to rebuild degraded replicas while actual disk usage remains below free space

## Verification
- Patched live setting storage-over-provisioning-percentage=150
- Validated Longhorn Application manifest with kubectl dry-run