### PR TITLE
fix: expose Wazuh dashboard through ingress only

### DIFF
--- a/Services/Security/Wazuh/indexer_stack/wazuh-dashboard/dashboard-svc.yaml
+++ b/Services/Security/Wazuh/indexer_stack/wazuh-dashboard/dashboard-svc.yaml
@@ -15,13 +15,8 @@ metadata:
   labels:
     app: wazuh-dashboard
     # dns: route53
-  annotations:
-    # domainName: 'changeme'
-    # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: 'changeme'
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: '443'
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: https
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   selector:
     app: wazuh-dashboard
   ports:


### PR DESCRIPTION
## Summary
- Change Wazuh dashboard Service from LoadBalancer to ClusterIP
- Remove cloud load balancer annotations that do not apply on k3s
- Prevent klipper-lb pods from trying to bind host port 443 and staying Pending

## Verification
- kubectl apply --dry-run=client -k Services/Security/Wazuh
- patched live service to ClusterIP
- Wazuh dashboard remains reachable via Traefik IngressRoute