### PR TITLE
feat: add Dionysus image storage and tool alerts

### DIFF
--- a/Services/Platform/Observability/GrafanaDashboards/homelab-security-platform.dashboard.configmap.yaml
+++ b/Services/Platform/Observability/GrafanaDashboards/homelab-security-platform.dashboard.configmap.yaml
@@ -250,6 +250,66 @@ data:
               "expr": "{namespace=\"woodpecker\"}"
             }
           ]
+        },
+        {
+          "id": 11,
+          "type": "logs",
+          "title": "Dionysus logs",
+          "gridPos": {
+            "x": 0,
+            "y": 28,
+            "w": 8,
+            "h": 8
+          },
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"dionysus\"} |~ \"(?i)(error|exception|traceback|warn|failed)\""
+            }
+          ]
+        },
+        {
+          "id": 12,
+          "type": "logs",
+          "title": "Argo CD logs",
+          "gridPos": {
+            "x": 8,
+            "y": 28,
+            "w": 8,
+            "h": 8
+          },
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"argocd\"} |~ \"(?i)(error|failed|denied|panic|timeout)\""
+            }
+          ]
+        },
+        {
+          "id": 13,
+          "type": "logs",
+          "title": "Longhorn logs",
+          "gridPos": {
+            "x": 16,
+            "y": 28,
+            "w": 8,
+            "h": 8
+          },
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"longhorn-system\"} |~ \"(?i)(error|failed|faulted|degraded|timeout)\""
+            }
+          ]
         }
       ]
     }

--- a/Services/Platform/Observability/GrafanaDashboards/homelab-tool-alerts.prometheusrule.yaml
+++ b/Services/Platform/Observability/GrafanaDashboards/homelab-tool-alerts.prometheusrule.yaml
@@ -1,0 +1,124 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: homelab-tool-alerts
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: homelab-tool-alerts
+    app.kubernetes.io/component: observability
+    prometheus: kube-prometheus-stack-prometheus
+    role: alert-rules
+spec:
+  groups:
+    - name: homelab.tool-health
+      rules:
+        - alert: ArgoCDApplicationUnhealthy
+          expr: max by (name, namespace, health_status, sync_status) (argocd_app_info{health_status!="Healthy"}) > 0
+          for: 10m
+          labels:
+            severity: warning
+            tool: argocd
+          annotations:
+            summary: "Argo CD application {{ $labels.name }} is {{ $labels.health_status }}"
+            description: "Application {{ $labels.namespace }}/{{ $labels.name }} has sync status {{ $labels.sync_status }} and health {{ $labels.health_status }} for more than 10 minutes."
+        - alert: ArgoCDApplicationOutOfSync
+          expr: max by (name, namespace, sync_status) (argocd_app_info{sync_status!="Synced"}) > 0
+          for: 15m
+          labels:
+            severity: warning
+            tool: argocd
+          annotations:
+            summary: "Argo CD application {{ $labels.name }} is {{ $labels.sync_status }}"
+            description: "Application {{ $labels.namespace }}/{{ $labels.name }} has not been Synced for more than 15 minutes."
+        - alert: LonghornVolumeUnhealthy
+          expr: longhorn_volume_robustness != 1
+          for: 10m
+          labels:
+            severity: critical
+            tool: longhorn
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} is not healthy"
+            description: "Longhorn reports volume {{ $labels.volume }} robustness as {{ $value }} for more than 10 minutes."
+        - alert: DionysusApiUnavailable
+          expr: kube_deployment_status_replicas_available{namespace="dionysus", deployment="dionysus-api"} < 1
+          for: 5m
+          labels:
+            severity: critical
+            tool: dionysus
+          annotations:
+            summary: "Dionysus API has no available replicas"
+            description: "The dionysus-api Deployment has had fewer than one available replica for more than 5 minutes."
+        - alert: DionysusWebUnavailable
+          expr: kube_deployment_status_replicas_available{namespace="dionysus", deployment="dionysus-web"} < 1
+          for: 5m
+          labels:
+            severity: critical
+            tool: dionysus
+          annotations:
+            summary: "Dionysus web has no available replicas"
+            description: "The dionysus-web Deployment has had fewer than one available replica for more than 5 minutes."
+        - alert: DionysusPersistentVolumeFilling
+          expr: kubelet_volume_stats_used_bytes{namespace="dionysus"} / kubelet_volume_stats_capacity_bytes{namespace="dionysus"} > 0.85
+          for: 15m
+          labels:
+            severity: warning
+            tool: dionysus
+          annotations:
+            summary: "Dionysus PVC {{ $labels.persistentvolumeclaim }} is above 85% used"
+            description: "PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} is {{ $value | humanizePercentage }} full."
+        - alert: WazuhManagerUnavailable
+          expr: kube_statefulset_status_replicas_ready{namespace="wazuh", statefulset="wazuh-manager-master"} < 1
+          for: 10m
+          labels:
+            severity: critical
+            tool: wazuh
+          annotations:
+            summary: "Wazuh manager master is unavailable"
+            description: "The Wazuh manager master StatefulSet has had fewer than one ready replica for more than 10 minutes."
+        - alert: FalcoPodsUnavailable
+          expr: kube_daemonset_status_number_ready{namespace="falco", daemonset="falco"} < kube_daemonset_status_desired_number_scheduled{namespace="falco", daemonset="falco"}
+          for: 10m
+          labels:
+            severity: warning
+            tool: falco
+          annotations:
+            summary: "Falco is not ready on every scheduled node"
+            description: "Falco ready pod count is below desired for more than 10 minutes."
+        - alert: TrivyOperatorUnavailable
+          expr: kube_deployment_status_replicas_available{namespace="trivy-system", deployment="trivy-operator"} < 1
+          for: 10m
+          labels:
+            severity: warning
+            tool: trivy
+          annotations:
+            summary: "Trivy Operator is unavailable"
+            description: "The Trivy Operator deployment has no available replicas for more than 10 minutes."
+        - alert: WoodpeckerServerUnavailable
+          expr: kube_deployment_status_replicas_available{namespace="woodpecker", deployment="woodpecker-server"} < 1
+          for: 10m
+          labels:
+            severity: warning
+            tool: woodpecker
+          annotations:
+            summary: "Woodpecker server is unavailable"
+            description: "The Woodpecker server deployment has no available replicas for more than 10 minutes."
+    - name: homelab.workload-logs
+      rules:
+        - alert: ContainerRestartLooping
+          expr: increase(kube_pod_container_status_restarts_total{namespace=~"argocd|cert-manager|dionysus|falco|longhorn-system|monitoring|trivy-system|wazuh|woodpecker"}[15m]) > 3
+          for: 5m
+          labels:
+            severity: warning
+            tool: kubernetes
+          annotations:
+            summary: "{{ $labels.namespace }}/{{ $labels.pod }} is restarting repeatedly"
+            description: "Container {{ $labels.container }} restarted more than 3 times in 15 minutes. Check the Grafana tool log dashboard for pod logs."
+        - alert: PodStuckNotReady
+          expr: sum by (namespace, pod, phase) (kube_pod_status_phase{namespace=~"argocd|cert-manager|dionysus|falco|longhorn-system|monitoring|trivy-system|wazuh|woodpecker", phase=~"Pending|Unknown|Failed"} == 1) > 0
+          for: 10m
+          labels:
+            severity: warning
+            tool: kubernetes
+          annotations:
+            summary: "{{ $labels.namespace }}/{{ $labels.pod }} is {{ $labels.phase }}"
+            description: "Pod {{ $labels.namespace }}/{{ $labels.pod }} has been stuck outside Running/Succeeded for more than 10 minutes."

--- a/Services/Platform/Observability/GrafanaDashboards/kustomization.yaml
+++ b/Services/Platform/Observability/GrafanaDashboards/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
   - homelab-security-platform.dashboard.configmap.yaml
+  - homelab-tool-alerts.prometheusrule.yaml

--- a/Services/Utilities/Dionysus/api.deployment.yaml
+++ b/Services/Utilities/Dionysus/api.deployment.yaml
@@ -31,6 +31,8 @@ spec:
                   key: DATABASE_URL
             - name: CORS_ORIGINS
               value: https://dionysus.saaby.no,http://localhost:5173,http://127.0.0.1:5173
+            - name: WINE_IMAGE_STORAGE_DIR
+              value: /data/wine-images
           ports:
             - name: http
               containerPort: 8000
@@ -47,3 +49,10 @@ spec:
               port: http
             initialDelaySeconds: 15
             periodSeconds: 20
+          volumeMounts:
+            - name: wine-images
+              mountPath: /data/wine-images
+      volumes:
+        - name: wine-images
+          persistentVolumeClaim:
+            claimName: dionysus-wine-images

--- a/Services/Utilities/Dionysus/kustomization.yaml
+++ b/Services/Utilities/Dionysus/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - namespace.yaml
   - postgres.statefulset.yaml
   - postgres.service.yaml
+  - wine-images.pvc.yaml
   - api.deployment.yaml
   - lwin-sync.cronjob.yaml
   - api.service.yaml

--- a/Services/Utilities/Dionysus/wine-images.pvc.yaml
+++ b/Services/Utilities/Dionysus/wine-images.pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dionysus-wine-images
+  namespace: dionysus
+  labels:
+    app.kubernetes.io/name: dionysus
+    app.kubernetes.io/component: wine-images
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 5Gi


### PR DESCRIPTION
## Summary
- add Grafana/Prometheus alert rules for Argo CD, Longhorn, Dionysus, Wazuh, Falco, Trivy, Woodpecker, and Kubernetes restart/pod states
- add focused Loki log panels for Dionysus, Argo CD, and Longhorn to the homelab Grafana dashboard
- add a Longhorn-backed PVC and API volume mount for Dionysus wine image storage

## Test plan
- kubectl kustomize Services/Platform/Observability/GrafanaDashboards
- kubectl kustomize Services/Utilities/Dionysus
- kubectl apply --dry-run=client -k Services/Utilities/Dionysus
- kubectl apply --dry-run=client -k Services/Platform/Observability/GrafanaDashboards
- kubectl apply --dry-run=server -k Services/Utilities/Dionysus
- kubectl apply --dry-run=server -k Services/Platform/Observability/GrafanaDashboards