### PR TITLE
feat: add security tool detection forwarding

### DIFF
--- a/Services/Platform/Falco/falco.application.yaml
+++ b/Services/Platform/Falco/falco.application.yaml
@@ -24,6 +24,51 @@ spec:
         metrics:
           enabled: true
           outputRule: true
+        customRules:
+          homelab-rules.yaml: |-
+            - rule: Homelab Interactive Shell In Application Container
+              desc: An interactive shell was spawned in a non-platform application container.
+              condition: >
+                spawned_process and container and proc.name in (bash, sh, zsh, fish, ash)
+                and not k8s.ns.name in (kube-system, argocd, monitoring, longhorn-system, falco, wazuh, trivy-system, cert-manager)
+              output: >
+                Interactive shell spawned in application container
+                (user=%user.name command=%proc.cmdline container=%container.name image=%container.image.repository:%container.image.tag pod=%k8s.pod.name ns=%k8s.ns.name)
+              priority: WARNING
+              tags: [container, shell, homelab, mitre_execution]
+
+            - rule: Homelab Package Manager In Application Container
+              desc: Package manager execution inside an application container often indicates live debugging or post-compromise tooling.
+              condition: >
+                spawned_process and container and proc.name in (apk, apt, apt-get, yum, dnf, microdnf, pip, pip3, npm, yarn, pnpm, curl, wget)
+                and not k8s.ns.name in (kube-system, argocd, monitoring, longhorn-system, falco, wazuh, trivy-system, cert-manager)
+              output: >
+                Package/download tool executed in application container
+                (user=%user.name command=%proc.cmdline container=%container.name image=%container.image.repository:%container.image.tag pod=%k8s.pod.name ns=%k8s.ns.name)
+              priority: WARNING
+              tags: [container, package_management, homelab, mitre_execution]
+
+            - rule: Homelab Sensitive Host Path Write From Container
+              desc: Container attempted to write to sensitive host or system paths.
+              condition: >
+                open_write and container and fd.name startswith /host/etc
+                or open_write and container and fd.name startswith /host/boot
+                or open_write and container and fd.name startswith /host/usr/bin
+                or open_write and container and fd.name startswith /host/usr/sbin
+              output: >
+                Sensitive host path write from container
+                (user=%user.name file=%fd.name command=%proc.cmdline container=%container.name pod=%k8s.pod.name ns=%k8s.ns.name)
+              priority: CRITICAL
+              tags: [filesystem, host_path, homelab, mitre_persistence]
+
+            - rule: Homelab Known Miner Process In Container
+              desc: Known crypto-mining process name started inside a container.
+              condition: spawned_process and container and proc.name in (xmrig, minerd, cpuminer, cryptonight, kinsing)
+              output: >
+                Known miner process started in container
+                (user=%user.name command=%proc.cmdline container=%container.name image=%container.image.repository:%container.image.tag pod=%k8s.pod.name ns=%k8s.ns.name)
+              priority: CRITICAL
+              tags: [container, cryptomining, homelab, mitre_impact]
         serviceMonitor:
           create: true
         falcosidekick:

--- a/Services/Platform/Observability/GrafanaDashboards/homelab-security-platform.dashboard.configmap.yaml
+++ b/Services/Platform/Observability/GrafanaDashboards/homelab-security-platform.dashboard.configmap.yaml
@@ -310,6 +310,46 @@ data:
               "expr": "{namespace=\"longhorn-system\"} |~ \"(?i)(error|failed|faulted|degraded|timeout)\""
             }
           ]
+        },
+        {
+          "id": 14,
+          "type": "logs",
+          "title": "Falco high-signal detections",
+          "gridPos": {
+            "x": 0,
+            "y": 36,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"falco\"} |~ \"Homelab|CRITICAL|WARNING|miner|Sensitive host path|Interactive shell|Package/download\""
+            }
+          ]
+        },
+        {
+          "id": 15,
+          "type": "logs",
+          "title": "Wazuh high-signal alerts",
+          "gridPos": {
+            "x": 12,
+            "y": 36,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"wazuh\", container=\"wazuh-alerts-to-stdout\"} |~ \"critical_file_change|auth_bruteforce|host_compromise|vulnerability|rootkit|level[^0-9]*(9|10|11|12|13|14|15)\""
+            }
+          ]
         }
       ]
     }

--- a/Services/Security/Wazuh/kustomization.yml
+++ b/Services/Security/Wazuh/kustomization.yml
@@ -23,6 +23,7 @@ configMapGenerator:
     files:
       - wazuh_managers/wazuh_conf/master.conf
       - wazuh_managers/wazuh_conf/worker.conf
+      - wazuh_managers/wazuh_conf/local_rules.xml
   - name: dashboard-conf
     files:
       - indexer_stack/wazuh-dashboard/dashboard_conf/opensearch_dashboards.yml

--- a/Services/Security/Wazuh/wazuh_managers/wazuh-master-sts.yaml
+++ b/Services/Security/Wazuh/wazuh_managers/wazuh-master-sts.yaml
@@ -54,6 +54,10 @@ spec:
               mountPath: /wazuh-config-mount/etc/ossec.conf
               subPath: master.conf
               readOnly: true
+            - name: config
+              mountPath: /var/ossec/etc/rules/local_rules.xml
+              subPath: local_rules.xml
+              readOnly: true
             - name: filebeat-certs
               mountPath: /etc/ssl/root-ca.pem
               readOnly: true
@@ -146,6 +150,20 @@ spec:
                 secretKeyRef:
                   name: wazuh-cluster-key
                   key: key
+        - name: wazuh-alerts-to-stdout
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              mkdir -p /var/ossec/logs/alerts
+              touch /var/ossec/logs/alerts/alerts.json
+              tail -n +1 -F /var/ossec/logs/alerts/alerts.json
+          volumeMounts:
+            - name: wazuh-manager-master
+              mountPath: /var/ossec/logs
+              subPath: wazuh/var/ossec/logs
   volumeClaimTemplates:
     - metadata:
         name: wazuh-manager-master

--- a/Services/Security/Wazuh/wazuh_managers/wazuh-worker-sts.yaml
+++ b/Services/Security/Wazuh/wazuh_managers/wazuh-worker-sts.yaml
@@ -57,6 +57,10 @@ spec:
               mountPath: /wazuh-config-mount/etc/ossec.conf
               subPath: worker.conf
               readOnly: true
+            - name: config
+              mountPath: /var/ossec/etc/rules/local_rules.xml
+              subPath: local_rules.xml
+              readOnly: true
             - name: filebeat-certs
               mountPath: /etc/ssl/root-ca.pem
               readOnly: true
@@ -133,6 +137,20 @@ spec:
                 secretKeyRef:
                   name: wazuh-cluster-key
                   key: key
+        - name: wazuh-alerts-to-stdout
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              mkdir -p /var/ossec/logs/alerts
+              touch /var/ossec/logs/alerts/alerts.json
+              tail -n +1 -F /var/ossec/logs/alerts/alerts.json
+          volumeMounts:
+            - name: wazuh-manager-worker
+              mountPath: /var/ossec/logs
+              subPath: wazuh/var/ossec/logs
   volumeClaimTemplates:
     - metadata:
         name: wazuh-manager-worker

--- a/Services/Security/Wazuh/wazuh_managers/wazuh_conf/local_rules.xml
+++ b/Services/Security/Wazuh/wazuh_managers/wazuh_conf/local_rules.xml
@@ -1,0 +1,51 @@
+<!--
+  Homelab-focused Wazuh rules.
+  These enrich existing Wazuh detections into higher-signal groups that are easy
+  to query from Grafana/Loki after the manager alert stream is tailed to stdout.
+-->
+<group name="homelab,kubernetes,syscheck,authentication,">
+  <rule id="100100" level="12">
+    <if_group>syscheck</if_group>
+    <field name="file">/etc/sudoers|/etc/passwd|/etc/shadow|/etc/ssh/sshd_config|/boot/</field>
+    <description>Critical host configuration file changed</description>
+    <mitre>
+      <id>T1070</id>
+      <id>T1098</id>
+    </mitre>
+    <group>host_integrity,critical_file_change,</group>
+  </rule>
+
+  <rule id="100101" level="10" frequency="5" timeframe="300">
+    <if_matched_group>authentication_failed</if_matched_group>
+    <description>Repeated authentication failures on a homelab node</description>
+    <mitre>
+      <id>T1110</id>
+    </mitre>
+    <group>auth_bruteforce,</group>
+  </rule>
+
+  <rule id="100102" level="12">
+    <if_group>rootcheck</if_group>
+    <description>Rootcheck reported a possible host compromise indicator</description>
+    <mitre>
+      <id>T1014</id>
+    </mitre>
+    <group>rootkit,host_compromise,</group>
+  </rule>
+
+  <rule id="100103" level="9">
+    <if_group>vulnerability-detector</if_group>
+    <field name="vulnerability.severity">Critical|High</field>
+    <description>High or critical vulnerability detected by Wazuh</description>
+    <mitre>
+      <id>T1190</id>
+    </mitre>
+    <group>vulnerability,patching,</group>
+  </rule>
+
+  <rule id="100104" level="8">
+    <if_group>syscollector</if_group>
+    <description>System inventory change detected on a homelab node</description>
+    <group>inventory_change,</group>
+  </rule>
+</group>


### PR DESCRIPTION
## Summary
- add Falco homelab runtime detection rules for interactive shells, package/download tooling, sensitive host path writes, and known miner processes
- add Wazuh local high-signal rules for critical file integrity changes, auth brute force, rootcheck compromise indicators, high/critical vulnerabilities, and inventory changes
- tail Wazuh manager alerts.json to stdout so Promtail/Loki can carry Wazuh alerts into Grafana
- add targeted Grafana log panels for Falco high-signal detections and Wazuh high-signal alerts

## Test plan
- helm template falco chart with extracted values
- xmllint --noout Wazuh local_rules.xml
- kubectl apply --dry-run=client/server for Falco Application, Wazuh kustomize, and Grafana dashboards
- Grafana dashboard JSON parse check