### PR TITLE
fix(longhorn): harden storage defaults

### DIFF
--- a/Services/Platform/Longhorn/README.md
+++ b/Services/Platform/Longhorn/README.md
@@ -1,0 +1,45 @@
+# Longhorn storage policy
+
+Longhorn is used for replicated in-cluster block storage, not as a substitute for
+application-level high availability or off-cluster backups.
+
+## Cluster defaults
+
+- `local-path` remains the default StorageClass for accidental/unspecified PVCs.
+- Workloads must explicitly opt in to Longhorn with `storageClassName: longhorn`.
+- Longhorn volumes default to 3 replicas and strict anti-affinity across nodes/disks.
+- Over-provisioning is disabled (`100%`) and reserve/minimum free capacity is kept so
+  rebuilds have room to complete.
+
+## Workload placement
+
+Use Longhorn for small, important state:
+
+- CI server metadata
+- small application databases
+- security/observability control-plane state
+
+Avoid Longhorn for disposable or high-churn data when possible:
+
+- build caches
+- temporary workspaces
+- regenerated logs/metrics
+- media/transcode scratch space
+
+For databases that must survive node/storage incidents with minimal downtime, prefer
+application-native replication or an external managed database over a single-writer
+PVC alone.
+
+## External storage recommendation
+
+External storage is worth considering for this homelab, but by workload type:
+
+- **Object storage/S3-compatible backup target**: strongly recommended for Longhorn
+  recurring backups and database dumps. This gives off-cluster recovery when Longhorn
+  itself is unhealthy.
+- **Managed Postgres**: recommended for critical app databases if uptime matters more
+  than self-hosting purity.
+- **NFS/SMB NAS**: useful for shared media and bulk files, but not a fix for database
+  HA and often weaker than Longhorn for small synchronous writes.
+- **Ceph/Rook**: viable only if the cluster grows and we accept more operational
+  complexity; not a free stability upgrade on three small nodes.

--- a/Services/Platform/Longhorn/longhorn.application.yaml
+++ b/Services/Platform/Longhorn/longhorn.application.yaml
@@ -15,13 +15,36 @@ spec:
       releaseName: longhorn
       valuesObject:
         persistence:
-          defaultClass: true
-          defaultClassReplicaCount: 2
+          # Keep local-path as the cluster default and require workloads to opt in
+          # to replicated Longhorn storage explicitly.
+          defaultClass: false
+          defaultClassReplicaCount: 3
+          defaultDataLocality: disabled
+        preUpgradeChecker:
+          # Longhorn recommends disabling the pre-upgrade Job for GitOps tools.
+          jobEnabled: false
+        csi:
+          podAntiAffinityPreset: hard
+          attacherReplicaCount: 3
+          provisionerReplicaCount: 3
+          resizerReplicaCount: 3
+          snapshotterReplicaCount: 3
         defaultSettings:
           defaultDataPath: /var/lib/longhorn
+          defaultReplicaCount: '{"v1":"3","v2":"3"}'
+          defaultDataLocality: disabled
           replicaAutoBalance: best-effort
-          storageReservedPercentageForDefaultDisk: 10
-          storageOverProvisioningPercentage: 150
+          replicaSoftAntiAffinity: false
+          replicaDiskSoftAntiAffinity: false
+          storageOverProvisioningPercentage: 100
+          storageMinimalAvailablePercentage: 25
+          storageReservedPercentageForDefaultDisk: 20
+          allowVolumeCreationWithDegradedAvailability: false
+          disableSchedulingOnCordonedNode: true
+          nodeDrainPolicy: block-if-contains-last-replica
+          concurrentReplicaRebuildPerNodeLimit: 2
+          rebuildConcurrentSyncLimit: 1
+          autoCleanupSystemGeneratedSnapshot: true
         ingress:
           enabled: true
           ingressClassName: traefik


### PR DESCRIPTION
## Summary
- make Longhorn opt-in instead of a competing default StorageClass
- set Longhorn defaults to 3 replicas, strict anti-affinity, no over-provisioning, and safer free-capacity reserves
- reduce rebuild concurrency and disable degraded volume creation to avoid unstable attach/rebuild storms
- document storage placement guidance and external storage recommendations

## Validation
- kubectl kustomize Services/Platform
- kubectl apply --dry-run=client -f rendered platform manifest
- helm template longhorn chart 1.12.0 with the updated values