### PR TITLE
fix(longhorn): keep default replicas within capacity

### DIFF
--- a/Services/Platform/Longhorn/README.md
+++ b/Services/Platform/Longhorn/README.md
@@ -7,7 +7,9 @@ application-level high availability or off-cluster backups.
 
 - `local-path` remains the default StorageClass for accidental/unspecified PVCs.
 - Workloads must explicitly opt in to Longhorn with `storageClassName: longhorn`.
-- Longhorn volumes default to 3 replicas and strict anti-affinity across nodes/disks.
+- Longhorn volumes default to 2 replicas with strict anti-affinity across nodes/disks
+  on the current cluster. Use 3 replicas for critical PVCs only after adding enough
+  Longhorn capacity or moving telemetry/cache workloads elsewhere.
 - Over-provisioning is disabled (`100%`) and reserve/minimum free capacity is kept so
   rebuilds have room to complete.
 

--- a/Services/Platform/Longhorn/longhorn.application.yaml
+++ b/Services/Platform/Longhorn/longhorn.application.yaml
@@ -18,7 +18,10 @@ spec:
           # Keep local-path as the cluster default and require workloads to opt in
           # to replicated Longhorn storage explicitly.
           defaultClass: false
-          defaultClassReplicaCount: 3
+          # Current nodes do not have enough reserved Longhorn capacity for all
+          # workloads at 3 replicas. Use 2 replicas now; move critical PVCs to
+          # 3 replicas after adding storage capacity or externalizing telemetry.
+          defaultClassReplicaCount: 2
           defaultDataLocality: disabled
         preUpgradeChecker:
           # Longhorn recommends disabling the pre-upgrade Job for GitOps tools.
@@ -31,7 +34,7 @@ spec:
           snapshotterReplicaCount: 3
         defaultSettings:
           defaultDataPath: /var/lib/longhorn
-          defaultReplicaCount: '{"v1":"3","v2":"3"}'
+          defaultReplicaCount: '{"v1":"2","v2":"2"}'
           defaultDataLocality: disabled
           replicaAutoBalance: best-effort
           replicaSoftAntiAffinity: false


### PR DESCRIPTION
## Summary
- keep Longhorn opt-in and conservative capacity settings
- set default Longhorn replica count to 2 because current node capacity cannot schedule all workloads at 3 replicas
- document moving critical PVCs to 3 replicas only after adding capacity or reducing Longhorn load

## Validation
- kubectl kustomize Services/Platform
- kubectl apply --dry-run=client -f rendered platform manifest