### PR TITLE
docs(wazuh): add env secret bootstrap workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ Setup/Configuration/inventory/*.ini
 !Setup/Configuration/inventory/*.example.ini
 Setup/Configuration/failsafe/kubeconfig
 Setup/Configuration/.nixos-anywhere-extra-files/
+
+# Wazuh local runtime secrets/certs
+Services/Security/Wazuh/secrets.env
+Services/Security/Wazuh/certs/**/*.pem
+Services/Security/Wazuh/certs/**/*.csr
+Services/Security/Wazuh/certs/**/*.srl

--- a/Services/Security/Wazuh/README.md
+++ b/Services/Security/Wazuh/README.md
@@ -1,0 +1,30 @@
+# Wazuh secret handling
+
+Wazuh needs runtime credentials and internal TLS material that must not be committed to Git.
+
+## Current approach: ignored local files
+
+1. Copy `secrets.env.example` to `secrets.env`.
+2. Fill real values and keep permissions tight: `chmod 600 secrets.env`.
+3. Run `scripts/apply-secrets.sh` from the repository root.
+
+The script creates/applies these Kubernetes secrets in the `wazuh` namespace:
+
+- `wazuh-authd-pass`
+- `wazuh-cluster-key`
+- `indexer-cred`
+- `dashboard-cred`
+- `wazuh-api-cred`
+- `indexer-certs`
+- `dashboard-certs`
+
+The real `.env` and generated certificate files are ignored by Git.
+
+## SOPS migration TODO
+
+- [ ] Add an age key for Failsafe/Argo secret decryption.
+- [ ] Add `.sops.yaml` with path rules for `Services/**/secrets*.yaml`.
+- [ ] Convert Wazuh secrets to encrypted SOPS manifests.
+- [ ] Add Argo CD SOPS integration or a decrypt/apply bootstrap step.
+- [ ] Document key backup/rotation.
+- [ ] Remove dependence on local unencrypted `secrets.env` once SOPS is working.

--- a/Services/Security/Wazuh/SOPS-TODO.md
+++ b/Services/Security/Wazuh/SOPS-TODO.md
@@ -1,0 +1,21 @@
+# Wazuh SOPS migration TODO
+
+Current implementation uses an ignored local `.env` file plus generated local certificate files. This is intentionally simple and keeps raw secrets out of Git.
+
+## Later SOPS migration
+
+- [ ] Add an age key for the cluster/operator and document where the private key is stored.
+- [ ] Add `.sops.yaml` with creation rules for Kubernetes secret manifests under `Services/Security/Wazuh`.
+- [ ] Convert `secrets.env` values into encrypted SOPS-managed Kubernetes `Secret` manifests.
+- [ ] Decide how to handle internal Wazuh certificate material:
+  - [ ] encrypt generated cert/key files directly, or
+  - [ ] encrypt seed values and regenerate certs during bootstrap.
+- [ ] Add Argo CD SOPS decryption support, or deploy a controller such as External Secrets/KSOPS if preferred.
+- [ ] Remove the manual `.env` apply step after encrypted GitOps secrets are verified.
+- [ ] Document rotation procedure for Wazuh authd password, cluster key, indexer/dashboard credentials, and cert bundles.
+
+## Acceptance criteria
+
+- [ ] A fresh cluster sync can create all Wazuh runtime secrets without raw secret files outside Git except the SOPS private key.
+- [ ] Raw secrets are never committed.
+- [ ] Wazuh reaches `Synced/Healthy` after deleting and recreating the `wazuh` namespace.

--- a/Services/Security/Wazuh/scripts/apply-secrets.sh
+++ b/Services/Security/Wazuh/scripts/apply-secrets.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+WAZUH_DIR="$ROOT/Services/Security/Wazuh"
+ENV_FILE="${WAZUH_SECRET_ENV:-$WAZUH_DIR/secrets.env}"
+CERT_DIR="$WAZUH_DIR/certs/indexer_cluster"
+NS="${WAZUH_NAMESPACE:-wazuh}"
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "kubectl is required" >&2
+  exit 1
+fi
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "openssl is required. On Failsafe: nix shell nixpkgs#openssl -c $0" >&2
+  exit 1
+fi
+
+random_secret() {
+  openssl rand -base64 32 | tr -d '\n'
+}
+
+if [ ! -f "$ENV_FILE" ]; then
+  umask 077
+  cat >"$ENV_FILE" <<EOF
+WAZUH_AUTHD_PASS=$(random_secret)
+WAZUH_CLUSTER_KEY=$(random_secret)
+INDEXER_USERNAME=admin
+INDEXER_PASSWORD=$(random_secret)
+DASHBOARD_USERNAME=kibanaserver
+DASHBOARD_PASSWORD=$(random_secret)
+WAZUH_API_USERNAME=wazuh
+WAZUH_API_PASSWORD=$(random_secret)
+EOF
+  echo "Created $ENV_FILE"
+fi
+
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
+required=(
+  WAZUH_AUTHD_PASS WAZUH_CLUSTER_KEY
+  INDEXER_USERNAME INDEXER_PASSWORD
+  DASHBOARD_USERNAME DASHBOARD_PASSWORD
+  WAZUH_API_USERNAME WAZUH_API_PASSWORD
+)
+for key in "${required[@]}"; do
+  if [ -z "${!key:-}" ] || [[ "${!key}" == replace-* ]]; then
+    echo "$key is missing or still a placeholder in $ENV_FILE" >&2
+    exit 1
+  fi
+done
+
+kubectl get namespace "$NS" >/dev/null 2>&1 || kubectl create namespace "$NS"
+
+if [ ! -f "$CERT_DIR/root-ca.pem" ] || [ ! -f "$CERT_DIR/node.pem" ] || [ ! -f "$CERT_DIR/filebeat.pem" ] || [ ! -f "$CERT_DIR/dashboard.pem" ]; then
+  (cd "$CERT_DIR" && bash ./generate_certs.sh)
+fi
+
+kubectl -n "$NS" create secret generic wazuh-authd-pass \
+  --from-literal=authd.pass="$WAZUH_AUTHD_PASS" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n "$NS" create secret generic wazuh-cluster-key \
+  --from-literal=key="$WAZUH_CLUSTER_KEY" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n "$NS" create secret generic indexer-cred \
+  --from-literal=username="$INDEXER_USERNAME" \
+  --from-literal=password="$INDEXER_PASSWORD" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n "$NS" create secret generic dashboard-cred \
+  --from-literal=username="$DASHBOARD_USERNAME" \
+  --from-literal=password="$DASHBOARD_PASSWORD" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n "$NS" create secret generic wazuh-api-cred \
+  --from-literal=username="$WAZUH_API_USERNAME" \
+  --from-literal=password="$WAZUH_API_PASSWORD" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n "$NS" create secret generic indexer-certs \
+  --from-file=root-ca.pem="$CERT_DIR/root-ca.pem" \
+  --from-file=node.pem="$CERT_DIR/node.pem" \
+  --from-file=node-key.pem="$CERT_DIR/node-key.pem" \
+  --from-file=admin.pem="$CERT_DIR/admin.pem" \
+  --from-file=admin-key.pem="$CERT_DIR/admin-key.pem" \
+  --from-file=filebeat.pem="$CERT_DIR/filebeat.pem" \
+  --from-file=filebeat-key.pem="$CERT_DIR/filebeat-key.pem" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n "$NS" create secret generic dashboard-certs \
+  --from-file=root-ca.pem="$CERT_DIR/root-ca.pem" \
+  --from-file=cert.pem="$CERT_DIR/dashboard.pem" \
+  --from-file=key.pem="$CERT_DIR/dashboard-key.pem" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Wazuh runtime secrets applied to namespace $NS"

--- a/Services/Security/Wazuh/secrets.env.example
+++ b/Services/Security/Wazuh/secrets.env.example
@@ -1,0 +1,13 @@
+# Copy to secrets.env, chmod 600, then run scripts/apply-secrets.sh.
+# The real secrets.env is ignored by Git.
+
+WAZUH_AUTHD_PASS=replace-with-random-authd-password
+WAZUH_CLUSTER_KEY=replace-with-random-cluster-key
+
+# These usernames are referenced by the Wazuh manifests.
+INDEXER_USERNAME=admin
+INDEXER_PASSWORD=replace-with-indexer-admin-password
+DASHBOARD_USERNAME=kibanaserver
+DASHBOARD_PASSWORD=replace-with-dashboard-password
+WAZUH_API_USERNAME=wazuh
+WAZUH_API_PASSWORD=replace-with-wazuh-api-password


### PR DESCRIPTION
## Summary
- document ignored .env/cert workflow for Wazuh runtime secrets
- add secrets.env.example and apply-secrets helper
- add SOPS migration TODO

## Verification
- bash -n Services/Security/Wazuh/scripts/apply-secrets.sh
- kubectl kustomize Services/Security
- kubectl apply --dry-run=client -f /tmp/security-render.yaml